### PR TITLE
Add dynamic Ollama model dropdown

### DIFF
--- a/src/api/ollama.ts
+++ b/src/api/ollama.ts
@@ -39,4 +39,20 @@ async function createChatCompletionStream(
   }
 }
 
-export default { createChatCompletionStream }
+async function listModels(ollamaEndpoint: string): Promise<string[]> {
+  try {
+    const formatedEndpoint = ollamaEndpoint.replace(/\/$/, '')
+    const response = await axios.get(`${formatedEndpoint}/api/tags`)
+    if (response.status !== 200) {
+      throw new Error(`Status code: ${response.status}`)
+    }
+    return (
+      response.data?.models?.map((item: { name: string }) => item.name) || []
+    )
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
+export default { createChatCompletionStream, listModels }


### PR DESCRIPTION
## Summary
- request Ollama models from `/api/tags`
- update Home and Settings pages to populate model dropdowns dynamically

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68481a5c4c348324af872a32e43283e3