### PR TITLE
Fix YAML run step and keep quoted key

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build and Push Docker Image
 
-on:
+"on":
   push:
     tags:
       - '*'
@@ -16,7 +16,8 @@ jobs:
       - name: Set lowercase repository name
         id: repo
         run: |
-          echo "repo=$(echo \"$GITHUB_REPOSITORY\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          repo=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
## Summary
- simplify the Docker workflow's repository name step

## Testing
- `yamllint .github/workflows/docker.yml`
- `actionlint -ignore 'action' .github/workflows/docker.yml`
- `yarn lint` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68483c072bc08324b2b1e640f732c8f7