### PR TITLE
Update rewriting logic to paragraph approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx,.vue src/",
     "cz": "git-cz",
     "release": "bump-version",
-    "lint:dpdm": "dpdm -T --tsconfig ./tsconfig.json --no-tree --no-warning --exit-code circular:1 src/main.ts"
+    "lint:dpdm": "dpdm -T --tsconfig ./tsconfig.json --no-tree --no-warning --exit-code circular:1 src/main.ts",
+    "test": "node --test"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -40,6 +40,52 @@ function insertResult(result: Ref<string>, insertType: Ref<string>): void {
   }
 }
 
+async function enableTrackChanges(): Promise<void> {
+  await Word.run(async context => {
+    context.document.changeTrackingMode = Word.ChangeTrackingMode.trackAll
+    await context.sync()
+  })
+}
+
+interface ParagraphInfo {
+  text: string
+  font: {
+    bold: boolean
+    color: string
+    name: string
+    size: number
+    italic: boolean
+    underline: Word.UnderlineType | string
+    highlightColor: string
+  }
+}
+
+async function rewriteSelectionParagraphs(
+  paragraphs: { reason: string; text: string }[],
+  fonts: ParagraphInfo['font'][]
+): Promise<void> {
+  await Word.run(async context => {
+    const range = context.document.getSelection()
+    const ps = range.paragraphs
+    ps.load('items')
+    await context.sync()
+
+    ps.items.forEach((p, idx) => {
+      if (idx >= paragraphs.length) {
+        return
+      }
+      const item = paragraphs[idx]
+      p.insertComment(item.reason)
+      p.insertText(item.text, 'Replace')
+      p.font.set(fonts[idx])
+    })
+
+    await context.sync()
+  })
+}
+
 export default {
-  insertResult
+  insertResult,
+  enableTrackChanges,
+  rewriteSelectionParagraphs
 }

--- a/src/api/ollama.ts
+++ b/src/api/ollama.ts
@@ -55,4 +55,33 @@ async function listModels(ollamaEndpoint: string): Promise<string[]> {
   }
 }
 
-export default { createChatCompletionStream, listModels }
+interface ChatCompletionOptions {
+  ollamaEndpoint: string
+  ollamaModel: string
+  messages: { role: string; content: string }[]
+  temperature: number
+}
+
+async function createChatCompletion(
+  options: ChatCompletionOptions
+): Promise<string> {
+  const formatedEndpoint = options.ollamaEndpoint.replace(/\/$/, '')
+  const response = await axios.post(
+    `${formatedEndpoint}/api/chat`,
+    {
+      model: options.ollamaModel,
+      options: { temperature: options.temperature },
+      stream: false,
+      messages: options.messages
+    },
+    { headers: { 'Content-Type': 'application/json' } }
+  )
+
+  if (response.status !== 200) {
+    throw new Error(`Status code: ${response.status}`)
+  }
+
+  return response.data?.message?.content?.replace(/\\n/g, '\n') ?? ''
+}
+
+export default { createChatCompletionStream, createChatCompletion, listModels }

--- a/test/ollamaRewrite.test.js
+++ b/test/ollamaRewrite.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert/strict')
+const { createChatCompletion } = require('../src/api/ollama')
+
+test('ollama returns reasoning and text', async () => {
+  const endpoint = process.env.OLLAMA_ENDPOINT
+  if (!endpoint) {
+    console.log('Skipping test because OLLAMA_ENDPOINT is not set')
+    return
+  }
+  const model = process.env.OLLAMA_MODEL || 'llama3'
+  const messages = [
+    { role: 'user', content: 'Return the JSON {"reason":"test","text":"hello"}'}
+  ]
+  const result = await createChatCompletion({
+    ollamaEndpoint: endpoint,
+    ollamaModel: model,
+    messages,
+    temperature: 0
+  })
+  const parsed = JSON.parse(result)
+  assert.equal(parsed.reason, 'test')
+  assert.equal(parsed.text, 'hello')
+})


### PR DESCRIPTION
## Summary
- enable revision tracking before edits
- rewrite selected text paragraph-by-paragraph via Ollama
- insert AI reasoning as comments and keep formatting
- expose a simple Ollama chat API
- add Node test skeleton for Ollama

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68485bd7f7a4832489d8cdcd6a8d2cca