### PR TITLE
Add JS wrapper for ollama API

### DIFF
--- a/src/api/ollama.js
+++ b/src/api/ollama.js
@@ -1,0 +1,23 @@
+const axios = require('axios');
+
+async function createChatCompletion(options) {
+  const formattedEndpoint = options.ollamaEndpoint.replace(/\/$/, '');
+  const response = await axios.post(
+    `${formattedEndpoint}/api/chat`,
+    {
+      model: options.ollamaModel,
+      options: { temperature: options.temperature },
+      stream: false,
+      messages: options.messages,
+    },
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Status code: ${response.status}`);
+  }
+
+  return response.data?.message?.content?.replace(/\\n/g, '\n') ?? '';
+}
+
+module.exports = { createChatCompletion };


### PR DESCRIPTION
## Summary
- add a CommonJS wrapper so tests can require `src/api/ollama`

## Testing
- `npm test` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68486694c18c8324a28baf0dc7a53d49