### PR TITLE
Add openwebui fetch module and tests

### DIFF
--- a/src/api/openwebui.js
+++ b/src/api/openwebui.js
@@ -1,0 +1,34 @@
+/**
+ * Use the built in fetch API available in modern Node versions instead of
+ * relying on axios. This mirrors the functionality of the TypeScript
+ * openweb API but keeps it lightweight for tests or simple scripts.
+ */
+
+async function createChatCompletion(options) {
+  const formattedEndpoint = options.openwebEndpoint.replace(/\/$/, '');
+  const payload = {
+    model: options.openwebModel,
+    messages: options.messages,
+    stream: false,
+    temperature: options.temperature,
+  };
+  if (options.collections && options.collections.length) {
+    payload.metadata = { collections: options.collections };
+  }
+
+  const response = await fetch(`${formattedEndpoint}/openai/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Status code: ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  return data?.choices?.[0]?.message?.content?.replace(/\\n/g, '\n') ?? '';
+}
+
+module.exports = { createChatCompletion };

--- a/test/openwebuiFetch.test.js
+++ b/test/openwebuiFetch.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { createChatCompletion } = require('../src/api/openwebui');
+
+test('createChatCompletion sends correct request and parses result', async () => {
+  let calledUrl = '';
+  let calledOptions;
+  const mockResponse = {
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content: 'hello\\nworld' } }] })
+  };
+  global.fetch = async (url, options) => {
+    calledUrl = url;
+    calledOptions = options;
+    return mockResponse;
+  };
+
+  const result = await createChatCompletion({
+    openwebEndpoint: 'http://test/',
+    openwebModel: 'm',
+    messages: [{ role: 'user', content: 'c' }],
+    temperature: 1,
+    collections: ['a', 'b']
+  });
+
+  assert.equal(calledUrl, 'http://test/openai/chat/completions');
+  assert.equal(calledOptions.method, 'POST');
+  const body = JSON.parse(calledOptions.body);
+  assert.equal(body.model, 'm');
+  assert.deepEqual(body.metadata, { collections: ['a', 'b'] });
+  assert.equal(result, 'hello\nworld');
+});


### PR DESCRIPTION
## Summary
- add a lightweight `openwebui.js` helper to call Open WebUI via `fetch`
- support optional collections metadata
- test the helper with a new `openwebuiFetch.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684919bbdbf88324a7887601c2ea4dc2