### PR TITLE
Fix OpenWebUI endpoint paths

### DIFF
--- a/src/api/openweb.ts
+++ b/src/api/openweb.ts
@@ -15,7 +15,7 @@ async function createChatCompletionStream(
   try {
     const endpoint = options.openwebEndpoint.replace(/\/$/, '')
     const response = await axios.post(
-      `${endpoint}/openai/chat/completions`,
+      `${endpoint}/api/chat/completions`,
       {
         model: options.openwebModel,
         messages: options.messages,
@@ -63,7 +63,7 @@ async function listModels(
 ): Promise<string[]> {
   try {
     const endpoint = openwebEndpoint.replace(/\/$/, '')
-    const response = await axios.get(`${endpoint}/api/v1/models`, {
+    const response = await axios.get(`${endpoint}/api/models`, {
       headers: {
         ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
       }
@@ -123,7 +123,7 @@ async function createChatCompletion(
 ): Promise<string> {
   const endpoint = options.openwebEndpoint.replace(/\/$/, '')
   const response = await axios.post(
-    `${endpoint}/openai/chat/completions`,
+    `${endpoint}/api/chat/completions`,
     {
       model: options.openwebModel,
       messages: options.messages,

--- a/src/api/openwebui.js
+++ b/src/api/openwebui.js
@@ -16,7 +16,7 @@ async function createChatCompletion(options) {
     payload.metadata = { collections: options.collections };
   }
 
-  const response = await fetch(`${formattedEndpoint}/openai/chat/completions`, {
+  const response = await fetch(`${formattedEndpoint}/api/chat/completions`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/test/openwebuiFetch.test.js
+++ b/test/openwebuiFetch.test.js
@@ -25,7 +25,7 @@ test('createChatCompletion sends correct request and parses result', async () =>
     openwebToken: 't'
   });
 
-  assert.equal(calledUrl, 'http://test/openai/chat/completions');
+  assert.equal(calledUrl, 'http://test/api/chat/completions');
   assert.equal(calledOptions.method, 'POST');
   const body = JSON.parse(calledOptions.body);
   assert.equal(body.model, 'm');


### PR DESCRIPTION
## Summary
- update OpenWebUI chat completion path to `/api/chat/completions`
- update OpenWebUI models endpoint to `/api/models`
- adjust tests for new path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494d37aa0c832495a4e92535031828