### PR TITLE
Improve Docker build speed

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Update Browserslist database
         run: npx update-browserslist-db@latest
@@ -46,6 +46,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          provenance: false
           tags: ghcr.io/${{ steps.repo.outputs.repo }}:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -58,6 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          provenance: false
           tags: ghcr.io/${{ steps.repo.outputs.repo }}:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-# Build Stage: use Node.js 18
-FROM node:18-alpine3.19 AS build-stage
+# Build Stage: use Node.js 20
+FROM node:20-alpine3.19 AS build-stage
 WORKDIR /app
 
 # Install dependencies first to leverage Docker cache
 COPY package.json yarn.lock ./
-RUN yarn config set network-timeout 300000 \
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/app/node_modules \
+    yarn config set network-timeout 300000 \
     && apk add --no-cache g++ make python3 \
     && yarn global add node-gyp \
     && yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary
- speed up Docker build by caching node_modules directory
- upgrade builder image to Node.js 20

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684951fde9548324860a8752134ead1b