### PR TITLE
Fix docker build failure with yarn classic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/app/node_modules \
-    yarn config set network-timeout 300000 \
+    corepack prepare yarn@1.22.19 --activate \
+    && yarn config set network-timeout 300000 \
     && apk add --no-cache g++ make python3 \
     && yarn global add node-gyp \
     && yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary
- fix docker build by pinning yarn classic in Dockerfile

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68495555029083248dfda874b406cd79