### PR TITLE
Fix Docker build by persisting node modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # Install dependencies first to leverage Docker cache
 COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.cache \
-    --mount=type=cache,target=/app/node_modules \
+    # Use cache for yarn's global cache but persist node_modules in the image
     corepack prepare yarn@1.22.19 --activate \
     && yarn config set network-timeout 300000 \
     && apk add --no-cache g++ make python3 \


### PR DESCRIPTION
## Summary
- persist `node_modules` during Docker build so `vue-cli-service` can run

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_6849584780d0832481d046eca4f89990