### PR TITLE
Populate OpenWebUI options after token

### DIFF
--- a/src/api/openweb.ts
+++ b/src/api/openweb.ts
@@ -78,6 +78,30 @@ async function listModels(
   }
 }
 
+async function listCollections(
+  openwebEndpoint: string,
+  openwebToken?: string
+): Promise<string[]> {
+  try {
+    const endpoint = openwebEndpoint.replace(/\/$/, '')
+    const response = await axios.get(
+      `${endpoint}/api/v1/retrieval/collections`,
+      {
+        headers: {
+          ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+        }
+      }
+    )
+    if (response.status !== 200) {
+      throw new Error(`Status code: ${response.status}`)
+    }
+    return response.data?.map((item: { name: string }) => item.name) || []
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
 async function queryCollections(
   openwebEndpoint: string,
   collections: string[],
@@ -156,5 +180,6 @@ export default {
   createChatCompletionStream,
   createChatCompletion,
   listModels,
-  queryCollections
+  queryCollections,
+  listCollections
 }

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -375,6 +375,7 @@ const openwebModelOptions = ref<{ label: string; value: string }[]>(
   settingPreset.openwebModelSelect.optionList
 )
 
+
 async function loadOllamaModels() {
   if (!settingForm.value.ollamaEndpoint) return
   const models = await API.ollama.listModels(settingForm.value.ollamaEndpoint)
@@ -395,6 +396,18 @@ async function loadOpenwebModels() {
   if (options.length > 0) {
     settingPreset.openwebModelSelect.optionList = options
     openwebModelOptions.value = options
+  }
+}
+
+async function loadOpenwebCollections() {
+  if (!settingForm.value.openwebEndpoint) return
+  const collections = await API.openweb.listCollections(
+    settingForm.value.openwebEndpoint,
+    settingForm.value.openwebToken
+  )
+  const options = collections.map(item => ({ label: item, value: item }))
+  if (options.length > 0) {
+    settingPreset.openwebCollections.optionList = options
   }
 }
 
@@ -605,6 +618,7 @@ const addWatch = () => {
     () => {
       if (['openweb', 'openweb-ui'].includes(settingForm.value.api)) {
         loadOpenwebModels()
+        loadOpenwebCollections()
       }
     }
   )
@@ -614,6 +628,7 @@ const addWatch = () => {
     () => {
       if (['openweb', 'openweb-ui'].includes(settingForm.value.api)) {
         loadOpenwebModels()
+        loadOpenwebCollections()
       }
     }
   )
@@ -625,6 +640,7 @@ const addWatch = () => {
         loadOllamaModels()
       } else if (val === 'openweb' || val === 'openweb-ui') {
         loadOpenwebModels()
+        loadOpenwebCollections()
       }
     }
   )
@@ -963,6 +979,7 @@ onBeforeMount(() => {
   addWatch()
   loadOllamaModels()
   loadOpenwebModels()
+  loadOpenwebCollections()
   initData()
 })
 </script>

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -210,6 +210,7 @@ const openwebModelOptions = ref<{ label: string; value: string }[]>(
   settingPreset.openwebModelSelect.optionList
 )
 
+
 async function loadOllamaModels() {
   if (!settingForm.value.ollamaEndpoint) return
   const models = await API.ollama.listModels(settingForm.value.ollamaEndpoint)
@@ -230,6 +231,18 @@ async function loadOpenwebModels() {
   if (options.length > 0) {
     settingPreset.openwebModelSelect.optionList = options
     openwebModelOptions.value = options
+  }
+}
+
+async function loadOpenwebCollections() {
+  if (!settingForm.value.openwebEndpoint) return
+  const collections = await API.openweb.listCollections(
+    settingForm.value.openwebEndpoint,
+    settingForm.value.openwebToken
+  )
+  const options = collections.map(item => ({ label: item, value: item }))
+  if (options.length > 0) {
+    settingPreset.openwebCollections.optionList = options
   }
 }
 
@@ -288,6 +301,7 @@ const addWatch = () => {
     () => {
       if (['openweb', 'openweb-ui'].includes(settingForm.value.api)) {
         loadOpenwebModels()
+        loadOpenwebCollections()
       }
     }
   )
@@ -297,6 +311,7 @@ const addWatch = () => {
     () => {
       if (['openweb', 'openweb-ui'].includes(settingForm.value.api)) {
         loadOpenwebModels()
+        loadOpenwebCollections()
       }
     }
   )
@@ -308,6 +323,7 @@ const addWatch = () => {
         loadOllamaModels()
       } else if (val === 'openweb' || val === 'openweb-ui') {
         loadOpenwebModels()
+        loadOpenwebCollections()
       }
     }
   )
@@ -317,6 +333,7 @@ onBeforeMount(() => {
   addWatch()
   loadOllamaModels()
   loadOpenwebModels()
+  loadOpenwebCollections()
 })
 
 function backToHome() {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,6 +5,7 @@ import {
   availableModelsForGroq,
   availableModelsForOllama,
   availableModelsForOpenweb,
+  availableCollectionsForOpenweb,
   languageMap
 } from './constant'
 
@@ -68,7 +69,8 @@ export const optionLists = {
   geminiModelList: getOptionList(availableModelsForGemini),
   ollamaModelList: getOptionList(availableModelsForOllama),
   groqModelList: getOptionList(availableModelsForGroq),
-  openwebModelList: getOptionList(availableModelsForOpenweb)
+  openwebModelList: getOptionList(availableModelsForOpenweb),
+  openwebCollectionList: getOptionList(availableCollectionsForOpenweb)
 }
 
 export const getLabel = (key: string) => `${key}Label`

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -109,6 +109,8 @@ export const availableModelsForOllama: IStringKeyMap = {
 
 export const availableModelsForOpenweb: IStringKeyMap = {}
 
+export const availableCollectionsForOpenweb: IStringKeyMap = {}
+
 export const availableModelsForGroq: IStringKeyMap = {
   'gemma2-9b-it': 'gemma2-9b-it',
   'gemma-7b-it': 'gemma-7b-it',

--- a/src/utils/settingPreset.ts
+++ b/src/utils/settingPreset.ts
@@ -5,7 +5,8 @@ import {
   availableModelsForGemini,
   availableModelsForGroq,
   availableModelsForOllama,
-  availableModelsForOpenweb
+  availableModelsForOpenweb,
+  availableCollectionsForOpenweb
 } from './constant'
 import { localStorageKey } from './enum'
 
@@ -173,7 +174,12 @@ export const settingPreset: Record<SettingNames, ISettingOption> = {
     availableModelsForOpenweb
   ),
   openwebTemperature: inputNumSetting(0.7, 'openwebTemperature', 'temperature'),
-  openwebCollections: defaultInputSetting,
+  openwebCollections: selectSetting(
+    '',
+    'openwebCollections',
+    optionLists.openwebCollectionList,
+    availableCollectionsForOpenweb
+  ),
   openwebToken: defaultInputSetting,
   groqAPIKey: defaultInputSetting,
   groqTemperature: inputNumSetting(0.5, 'groqTemperature', 'temperature'),


### PR DESCRIPTION
## Summary
- fetch available models and collections from OpenWebUI
- expose new `listCollections` API
- store collection options in settings
- update Settings and Home pages to load model and collection lists when OpenWebUI token is set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494cd1ab548324be69b046976124e1