### PR TITLE
Show raw API response before parsing

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -634,6 +634,8 @@ async function template(taskType: keyof typeof buildInPrompt | 'custom') {
         temperature: settingForm.value.openwebTemperature,
         openwebToken: settingForm.value.openwebToken
       })
+      // Always show the raw response first in the results box
+      result.value = response
       const parsed = JSON.parse(response)
       rewritten.push({ reason: parsed.reason, text: parsed.text })
     } catch (e) {


### PR DESCRIPTION
## Summary
- show API response in results field before rewriting JSON parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab399ab2c8324b9abb21eef71ce79