### PR TITLE
Add Open WebUI prompts

### DIFF
--- a/src/api/open-webui.js
+++ b/src/api/open-webui.js
@@ -36,4 +36,35 @@ async function createChatCompletion(options) {
   return data?.choices?.[0]?.message?.content?.replace(/\\n/g, '\n') ?? '';
 }
 
-module.exports = { createChatCompletion };
+async function listPrompts(openwebEndpoint, openwebToken) {
+  const formattedEndpoint = openwebEndpoint.replace(/\/$/, '');
+  const response = await fetch(`${formattedEndpoint}/api/prompts`, {
+    method: 'GET',
+    headers: {
+      ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Status code: ${response.status}`);
+  }
+
+  return await response.json();
+}
+
+async function listCharacters(openwebEndpoint, openwebToken) {
+  const formattedEndpoint = openwebEndpoint.replace(/\/$/, '');
+  const response = await fetch(`${formattedEndpoint}/api/characters`, {
+    method: 'GET',
+    headers: {
+      ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Status code: ${response.status}`);
+  }
+
+  return await response.json();
+}
+module.exports = { createChatCompletion, listPrompts, listCharacters };

--- a/src/api/open-webui.ts
+++ b/src/api/open-webui.ts
@@ -85,6 +85,59 @@ async function listModels(
   }
 }
 
+interface PromptItem {
+  command: string
+  title: string
+  content: string
+}
+
+async function listPrompts(
+  openwebEndpoint: string,
+  openwebToken?: string
+): Promise<PromptItem[]> {
+  try {
+    const endpoint = openwebEndpoint.replace(/\/$/, '')
+    const response = await axios.get(`${endpoint}/api/prompts`, {
+      headers: {
+        ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+      }
+    })
+    if (response.status !== 200) {
+      throw new Error(`Status code: ${response.status}`)
+    }
+    return Array.isArray(response.data) ? response.data : []
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
+interface CharacterItem {
+  name: string
+  prompt: string
+}
+
+async function listCharacters(
+  openwebEndpoint: string,
+  openwebToken?: string
+): Promise<CharacterItem[]> {
+  try {
+    const endpoint = openwebEndpoint.replace(/\/$/, '')
+    const response = await axios.get(`${endpoint}/api/characters`, {
+      headers: {
+        ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+      }
+    })
+    if (response.status !== 200) {
+      throw new Error(`Status code: ${response.status}`)
+    }
+    return Array.isArray(response.data) ? response.data : []
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
 async function queryCollections(
   openwebEndpoint: string,
   collections: string[],
@@ -163,5 +216,7 @@ export default {
   createChatCompletionStream,
   createChatCompletion,
   listModels,
+  listPrompts,
+  listCharacters,
   queryCollections
 }

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -254,11 +254,27 @@
               @change="handlePromptChange"
             >
               <el-option
-                v-for="item in promptList"
+                v-for="item in allPromptOptions"
                 :key="item.value"
                 :label="item.key"
                 :value="item.value"
-              />
+              >
+                <span>{{ item.key }}</span>
+                <el-tag
+                  v-if="item.source === 'openweb'"
+                  size="small"
+                  type="info"
+                  effect="light"
+                  style="margin-left:4px"
+                >WebUI</el-tag>
+                <el-tag
+                  v-else-if="item.source === 'openweb-character'"
+                  size="small"
+                  type="warning"
+                  effect="light"
+                  style="margin-left:4px"
+                >Character</el-tag>
+              </el-option>
             </el-select>
             <el-input
               v-model="prompt"
@@ -368,6 +384,9 @@ const openwebModelOptions = ref<{ label: string; value: string }[]>(
   settingPreset.openwebModelSelect.optionList
 )
 
+const openwebPromptList = ref<IStringKeyMap[]>([])
+const openwebCharacterList = ref<IStringKeyMap[]>([])
+
 async function loadOpenwebModels() {
   if (!settingForm.value.openwebEndpoint) return
   const models = await API.openweb.listModels(
@@ -379,6 +398,32 @@ async function loadOpenwebModels() {
     settingPreset.openwebModelSelect.optionList = options
     openwebModelOptions.value = options
   }
+}
+
+async function loadOpenwebPrompts() {
+  if (!settingForm.value.openwebEndpoint) return
+  const prompts = await API.openweb.listPrompts(
+    settingForm.value.openwebEndpoint,
+    settingForm.value.openwebToken
+  )
+  openwebPromptList.value = prompts.map(p => ({
+    key: p.title || p.command,
+    value: p.content,
+    source: 'openweb'
+  }))
+}
+
+async function loadOpenwebCharacters() {
+  if (!settingForm.value.openwebEndpoint) return
+  const characters = await API.openweb.listCharacters(
+    settingForm.value.openwebEndpoint,
+    settingForm.value.openwebToken
+  )
+  openwebCharacterList.value = characters.map(c => ({
+    key: c.name,
+    value: c.prompt,
+    source: 'openweb-character'
+  }))
 }
 
 // system prompt
@@ -400,6 +445,12 @@ const addPromptAlias = ref('')
 const addPromptValue = ref('')
 const removePromptVisible = ref(false)
 const removePromptValue = ref<any[]>([])
+
+const allPromptOptions = computed(() => [
+  ...promptList.value,
+  ...openwebPromptList.value,
+  ...openwebCharacterList.value
+])
 
 // result
 const result = ref('res')
@@ -511,6 +562,8 @@ const addWatch = () => {
     () => {
       if (settingForm.value.api === 'open-webui') {
         loadOpenwebModels()
+        loadOpenwebPrompts()
+        loadOpenwebCharacters()
       }
     }
   )
@@ -519,6 +572,8 @@ const addWatch = () => {
     () => {
       if (settingForm.value.api === 'open-webui') {
         loadOpenwebModels()
+        loadOpenwebPrompts()
+        loadOpenwebCharacters()
       }
     }
   )
@@ -527,6 +582,8 @@ const addWatch = () => {
     val => {
       if (val === 'open-webui') {
         loadOpenwebModels()
+        loadOpenwebPrompts()
+        loadOpenwebCharacters()
       }
     }
   )
@@ -545,7 +602,13 @@ async function initData() {
   }
   prompt.value = localStorage.getItem(localStorageKey.defaultPrompt) || ''
   await getPromptList()
-  if (promptList.value.find(item => item.value === prompt.value)) {
+  await loadOpenwebPrompts()
+  await loadOpenwebCharacters()
+  if (
+    [...promptList.value, ...openwebPromptList.value, ...openwebCharacterList.value].find(
+      item => item.value === prompt.value
+    )
+  ) {
     promptSelected.value = prompt.value
   }
 }
@@ -713,6 +776,8 @@ async function continueChat() {
 onBeforeMount(() => {
   addWatch()
   loadOpenwebModels()
+  loadOpenwebPrompts()
+  loadOpenwebCharacters()
   initData()
 })
 </script>

--- a/test/open-webuiFetch.test.js
+++ b/test/open-webuiFetch.test.js
@@ -1,6 +1,10 @@
 const assert = require('node:assert/strict');
 const { test } = require('node:test');
-const { createChatCompletion } = require('../src/api/open-webui');
+const {
+  createChatCompletion,
+  listPrompts,
+  listCharacters
+} = require('../src/api/open-webui');
 
 test('createChatCompletion sends correct request and parses result', async () => {
   let calledUrl = '';
@@ -32,4 +36,49 @@ test('createChatCompletion sends correct request and parses result', async () =>
   assert.deepEqual(body.metadata, { collections: ['a', 'b'] });
   assert.equal(calledOptions.headers.Authorization, 'Bearer t');
   assert.equal(result, 'hello\nworld');
+});
+
+
+test('listPrompts fetches prompt list', async () => {
+  let calledUrl = '';
+  let calledOptions;
+  const mockResponse = {
+    ok: true,
+    status: 200,
+    json: async () => [{ command: '/a', title: 'A', content: 'B' }]
+  };
+  global.fetch = async (url, options) => {
+    calledUrl = url;
+    calledOptions = options;
+    return mockResponse;
+  };
+
+  const result = await listPrompts('http://test/', 't');
+
+  assert.equal(calledUrl, 'http://test/api/prompts');
+  assert.equal(calledOptions.method, 'GET');
+  assert.equal(calledOptions.headers.Authorization, 'Bearer t');
+  assert.deepEqual(result, [{ command: '/a', title: 'A', content: 'B' }]);
+});
+
+test('listCharacters fetches character list', async () => {
+  let calledUrl = '';
+  let calledOptions;
+  const mockResponse = {
+    ok: true,
+    status: 200,
+    json: async () => [{ name: 'Alice', prompt: 'hello' }]
+  };
+  global.fetch = async (url, options) => {
+    calledUrl = url;
+    calledOptions = options;
+    return mockResponse;
+  };
+
+  const result = await listCharacters('http://test/', 't');
+
+  assert.equal(calledUrl, 'http://test/api/characters');
+  assert.equal(calledOptions.method, 'GET');
+  assert.equal(calledOptions.headers.Authorization, 'Bearer t');
+  assert.deepEqual(result, [{ name: 'Alice', prompt: 'hello' }]);
 });


### PR DESCRIPTION
## Summary
- fetch prompt list from Open WebUI API
- display Open WebUI prompts in the home page dropdown with a badge
- test prompt list fetching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ab1ffb71883248c4ff7906332c4b8