### PR TITLE
Add Open-WebUI collections toggle

### DIFF
--- a/src/api/open-webui.js
+++ b/src/api/open-webui.js
@@ -67,4 +67,20 @@ async function listCharacters(openwebEndpoint, openwebToken) {
 
   return await response.json();
 }
-module.exports = { createChatCompletion, listPrompts, listCharacters };
+
+async function listCollections(openwebEndpoint, openwebToken) {
+  const formattedEndpoint = openwebEndpoint.replace(/\/$/, '');
+  const response = await fetch(`${formattedEndpoint}/api/v1/retrieval/collections`, {
+    method: 'GET',
+    headers: {
+      ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Status code: ${response.status}`);
+  }
+
+  return await response.json();
+}
+module.exports = { createChatCompletion, listPrompts, listCharacters, listCollections };

--- a/src/api/open-webui.ts
+++ b/src/api/open-webui.ts
@@ -138,6 +138,27 @@ async function listCharacters(
   }
 }
 
+async function listCollections(
+  openwebEndpoint: string,
+  openwebToken?: string
+): Promise<string[]> {
+  try {
+    const endpoint = openwebEndpoint.replace(/\/$/, '')
+    const response = await axios.get(`${endpoint}/api/v1/retrieval/collections`, {
+      headers: {
+        ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+      }
+    })
+    if (response.status !== 200) {
+      throw new Error(`Status code: ${response.status}`)
+    }
+    return Array.isArray(response.data) ? response.data : []
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
 async function queryCollections(
   openwebEndpoint: string,
   collections: string[],
@@ -218,5 +239,6 @@ export default {
   listModels,
   listPrompts,
   listCharacters,
+  listCollections,
   queryCollections
 }

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -285,6 +285,19 @@
               @blur="handlePromptChange(prompt)"
             />
           </div>
+          <div class="config-section">
+            <div class="section-header">
+              <label class="section-label">{{ $t('openwebCollectionsLabel') }}</label>
+            </div>
+            <el-checkbox-group v-model="openwebCollectionSelected">
+              <el-checkbox
+                v-for="item in openwebCollectionOptions"
+                :key="item.value"
+                :label="item.value"
+                >{{ item.label }}</el-checkbox
+              >
+            </el-checkbox-group>
+          </div>
         </el-card>
 
         <el-card class="results-card" shadow="hover">
@@ -386,6 +399,16 @@ const openwebModelOptions = ref<{ label: string; value: string }[]>(
 
 const openwebPromptList = ref<IStringKeyMap[]>([])
 const openwebCharacterList = ref<IStringKeyMap[]>([])
+const openwebCollectionOptions = ref<{ label: string; value: string }[]>([])
+
+async function loadOpenwebCollections() {
+  if (!settingForm.value.openwebEndpoint) return
+  const cols = await API.openweb.listCollections(
+    settingForm.value.openwebEndpoint,
+    settingForm.value.openwebToken
+  )
+  openwebCollectionOptions.value = cols.map(item => ({ label: item, value: item }))
+}
 
 async function loadOpenwebModels() {
   if (!settingForm.value.openwebEndpoint) return
@@ -488,6 +511,18 @@ const currentModelSelect = computed({
   }
 })
 
+const openwebCollectionSelected = computed({
+  get() {
+    return settingForm.value.openwebCollections
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+  },
+  set(value: string[]) {
+    settingForm.value.openwebCollections = value.join(',')
+  }
+})
+
 async function getSystemPromptList() {
   const table = promptDbInstance.table('systemPrompt')
   const list = (await table.toArray()) as unknown as IStringKeyMap[]
@@ -564,6 +599,7 @@ const addWatch = () => {
         loadOpenwebModels()
         loadOpenwebPrompts()
         loadOpenwebCharacters()
+        loadOpenwebCollections()
       }
     }
   )
@@ -574,6 +610,7 @@ const addWatch = () => {
         loadOpenwebModels()
         loadOpenwebPrompts()
         loadOpenwebCharacters()
+        loadOpenwebCollections()
       }
     }
   )
@@ -584,6 +621,7 @@ const addWatch = () => {
         loadOpenwebModels()
         loadOpenwebPrompts()
         loadOpenwebCharacters()
+        loadOpenwebCollections()
       }
     }
   )
@@ -604,6 +642,7 @@ async function initData() {
   await getPromptList()
   await loadOpenwebPrompts()
   await loadOpenwebCharacters()
+  await loadOpenwebCollections()
   if (
     [...promptList.value, ...openwebPromptList.value, ...openwebCharacterList.value].find(
       item => item.value === prompt.value
@@ -780,6 +819,7 @@ onBeforeMount(() => {
   loadOpenwebModels()
   loadOpenwebPrompts()
   loadOpenwebCharacters()
+  loadOpenwebCollections()
   initData()
 })
 </script>

--- a/test/open-webuiFetch.test.js
+++ b/test/open-webuiFetch.test.js
@@ -3,7 +3,8 @@ const { test } = require('node:test');
 const {
   createChatCompletion,
   listPrompts,
-  listCharacters
+  listCharacters,
+  listCollections
 } = require('../src/api/open-webui');
 
 test('createChatCompletion sends correct request and parses result', async () => {
@@ -81,4 +82,26 @@ test('listCharacters fetches character list', async () => {
   assert.equal(calledOptions.method, 'GET');
   assert.equal(calledOptions.headers.Authorization, 'Bearer t');
   assert.deepEqual(result, [{ name: 'Alice', prompt: 'hello' }]);
+});
+
+test('listCollections fetches collection names', async () => {
+  let calledUrl = '';
+  let calledOptions;
+  const mockResponse = {
+    ok: true,
+    status: 200,
+    json: async () => ['c1', 'c2']
+  };
+  global.fetch = async (url, options) => {
+    calledUrl = url;
+    calledOptions = options;
+    return mockResponse;
+  };
+
+  const result = await listCollections('http://test/', 't');
+
+  assert.equal(calledUrl, 'http://test/api/v1/retrieval/collections');
+  assert.equal(calledOptions.method, 'GET');
+  assert.equal(calledOptions.headers.Authorization, 'Bearer t');
+  assert.deepEqual(result, ['c1', 'c2']);
 });


### PR DESCRIPTION
## Summary
- fetch collections via new `listCollections` API
- display available collections in a toggle list on the Prompts panel
- load collections when Open WebUI settings change
- test the new API helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab75ad3548324b0a11fc6220fa82e