### PR TITLE
Add collection picker and enhanced rewrite workflow

### DIFF
--- a/src/api/open-webui.js
+++ b/src/api/open-webui.js
@@ -67,4 +67,25 @@ async function listCharacters(openwebEndpoint, openwebToken) {
 
   return await response.json();
 }
-module.exports = { createChatCompletion, listPrompts, listCharacters };
+
+async function listCollections(openwebEndpoint, openwebToken) {
+  const formattedEndpoint = openwebEndpoint.replace(/\/$/, '');
+  const response = await fetch(`${formattedEndpoint}/api/knowledge/list`, {
+    method: 'GET',
+    headers: {
+      ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Status code: ${response.status}`);
+  }
+
+  return await response.json();
+}
+module.exports = {
+  createChatCompletion,
+  listPrompts,
+  listCharacters,
+  listCollections
+};

--- a/src/api/open-webui.ts
+++ b/src/api/open-webui.ts
@@ -138,6 +138,32 @@ async function listCharacters(
   }
 }
 
+interface KnowledgeItem {
+  id: string
+  name: string
+}
+
+async function listCollections(
+  openwebEndpoint: string,
+  openwebToken?: string
+): Promise<KnowledgeItem[]> {
+  try {
+    const endpoint = openwebEndpoint.replace(/\/$/, '')
+    const response = await axios.get(`${endpoint}/api/knowledge/list`, {
+      headers: {
+        ...(openwebToken ? { Authorization: `Bearer ${openwebToken}` } : {})
+      }
+    })
+    if (response.status !== 200) {
+      throw new Error(`Status code: ${response.status}`)
+    }
+    return Array.isArray(response.data) ? response.data : []
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
 async function queryCollections(
   openwebEndpoint: string,
   collections: string[],
@@ -218,5 +244,6 @@ export default {
   listModels,
   listPrompts,
   listCharacters,
+  listCollections,
   queryCollections
 }


### PR DESCRIPTION
## Summary
- allow fetching collections from Open WebUI and expose `listCollections` API
- show available collections in the Prompts section
- load collections when Open WebUI settings change
- rewrite paragraphs in a single request with numbering and legal basis comments

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684aba65c9d88324be7c9723edc5a0ef