### PR TITLE
Implement numbered paragraph rewrite

### DIFF
--- a/test/open-webuiRewrite.test.js
+++ b/test/open-webuiRewrite.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict')
 const { test } = require('node:test')
 const { createChatCompletion } = require('../src/api/open-webui')
 
-test('openwebui returns reasoning and text', async () => {
+test('openwebui returns numbered rewrite array', async () => {
   const endpoint = process.env.OPENWEB_ENDPOINT
   if (!endpoint) {
     console.log('Skipping test because OPENWEB_ENDPOINT is not set')
@@ -10,7 +10,7 @@ test('openwebui returns reasoning and text', async () => {
   }
   const model = process.env.OPENWEB_MODEL || 'gpt-3.5'
   const messages = [
-    { role: 'user', content: 'Return the JSON {"reason":"test","text":"hello"}'}
+    { role: 'user', content: 'Return the JSON [{"paragraph":1,"rewrittenText":"hello","legalBasisReasoning":"reason"}]' }
   ]
   const result = await createChatCompletion({
     openwebEndpoint: endpoint,
@@ -19,6 +19,7 @@ test('openwebui returns reasoning and text', async () => {
     temperature: 0
   })
   const parsed = JSON.parse(result)
-  assert.equal(parsed.reason, 'test')
-  assert.equal(parsed.text, 'hello')
+  assert.equal(Array.isArray(parsed), true)
+  assert.equal(parsed[0].paragraph, 1)
+  assert.equal(parsed[0].rewrittenText, 'hello')
 })


### PR DESCRIPTION
## Summary
- support rewrite requests with numbered paragraphs
- check custom prompt results and insert replacements accordingly
- update rewrite test to expect numbered array output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abd4a3e7083248e99c1d6eb7e4844