### PR TITLE
Add API endpoint & token inputs

### DIFF
--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -197,6 +197,11 @@ import { availableAPIs } from '@/utils/constant'
 import API from '@/api'
 import { SettingNames, settingPreset } from '@/utils/settingPreset'
 import useSettingForm from '@/utils/settingForm'
+import {
+  getApiInputSettings,
+  getApiNumSettings,
+  getApiSelectSettings
+} from '@/utils/settingHelpers'
 
 const router = useRouter()
 const { settingForm, settingFormKeys } = useSettingForm()
@@ -225,33 +230,6 @@ async function loadOpenwebModels() {
     settingPreset.openwebModelSelect.optionList = options
     openwebModelOptions.value = options
   }
-}
-
-const getApiInputSettings = (platform: string) => {
-  const prefix = platform.replace(/-/g, '')
-  return Object.keys(settingForm.value).filter(
-    key =>
-      (key.startsWith(platform) || key.startsWith(prefix)) &&
-      settingPreset[key as SettingNames].type === 'input'
-  )
-}
-
-const getApiNumSettings = (platform: string) => {
-  const prefix = platform.replace(/-/g, '')
-  return Object.keys(settingForm.value).filter(
-    key =>
-      (key.startsWith(platform) || key.startsWith(prefix)) &&
-      settingPreset[key as SettingNames].type === 'inputNum'
-  )
-}
-
-const getApiSelectSettings = (platform: string) => {
-  const prefix = platform.replace(/-/g, '')
-  return Object.keys(settingForm.value).filter(
-    key =>
-      (key.startsWith(platform) || key.startsWith(prefix)) &&
-      settingPreset[key as SettingNames].type === 'select'
-  )
 }
 
 const addWatch = () => {

--- a/src/utils/settingHelpers.js
+++ b/src/utils/settingHelpers.js
@@ -1,0 +1,35 @@
+function getPrefixesForPlatform(platform) {
+  const cleaned = platform.replace(/-/g, '')
+  const list = [platform, cleaned]
+  if (platform === 'open-webui') {
+    list.push('openweb')
+  }
+  return list
+}
+
+function filterSettingsByType(form, preset, platform, type) {
+  const prefixes = getPrefixesForPlatform(platform)
+  return Object.keys(form).filter(
+    key => prefixes.some(p => key.startsWith(p)) && preset[key].type === type
+  )
+}
+
+function getApiInputSettings(form, preset, platform) {
+  return filterSettingsByType(form, preset, platform, 'input')
+}
+
+function getApiNumSettings(form, preset, platform) {
+  return filterSettingsByType(form, preset, platform, 'inputNum')
+}
+
+function getApiSelectSettings(form, preset, platform) {
+  return filterSettingsByType(form, preset, platform, 'select')
+}
+
+module.exports = {
+  getPrefixesForPlatform,
+  filterSettingsByType,
+  getApiInputSettings,
+  getApiNumSettings,
+  getApiSelectSettings
+}

--- a/src/utils/settingHelpers.ts
+++ b/src/utils/settingHelpers.ts
@@ -1,0 +1,46 @@
+export type ComponentType = 'input' | 'select' | 'inputNum'
+
+export function getPrefixesForPlatform(platform: string): string[] {
+  const cleaned = platform.replace(/-/g, '')
+  const list = [platform, cleaned]
+  if (platform === 'open-webui') {
+    list.push('openweb')
+  }
+  return list
+}
+
+export function filterSettingsByType(
+  form: Record<string, any>,
+  preset: Record<string, { type?: ComponentType }>,
+  platform: string,
+  type: ComponentType
+): string[] {
+  const prefixes = getPrefixesForPlatform(platform)
+  return Object.keys(form).filter(
+    key => prefixes.some(p => key.startsWith(p)) && preset[key].type === type
+  )
+}
+
+export function getApiInputSettings(
+  form: Record<string, any>,
+  preset: Record<string, { type?: ComponentType }>,
+  platform: string
+): string[] {
+  return filterSettingsByType(form, preset, platform, 'input')
+}
+
+export function getApiNumSettings(
+  form: Record<string, any>,
+  preset: Record<string, { type?: ComponentType }>,
+  platform: string
+): string[] {
+  return filterSettingsByType(form, preset, platform, 'inputNum')
+}
+
+export function getApiSelectSettings(
+  form: Record<string, any>,
+  preset: Record<string, { type?: ComponentType }>,
+  platform: string
+): string[] {
+  return filterSettingsByType(form, preset, platform, 'select')
+}

--- a/test/settingHelpers.test.js
+++ b/test/settingHelpers.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+
+const {
+  getApiInputSettings,
+  getApiSelectSettings,
+  getApiNumSettings
+} = require('../src/utils/settingHelpers.js')
+
+test('getApiInputSettings returns endpoint and token for open-webui', () => {
+  const form = {
+    openwebEndpoint: '',
+    openwebToken: '',
+    openwebTemperature: 1,
+    openwebModelSelect: 'm'
+  }
+  const preset = {
+    openwebEndpoint: { type: 'input' },
+    openwebToken: { type: 'input' },
+    openwebTemperature: { type: 'inputNum' },
+    openwebModelSelect: { type: 'select' }
+  }
+  assert.deepEqual(
+    getApiInputSettings(form, preset, 'open-webui'),
+    ['openwebEndpoint', 'openwebToken']
+  )
+  assert.deepEqual(
+    getApiNumSettings(form, preset, 'open-webui'),
+    ['openwebTemperature']
+  )
+  assert.deepEqual(
+    getApiSelectSettings(form, preset, 'open-webui'),
+    ['openwebModelSelect']
+  )
+})


### PR DESCRIPTION
## Summary
- display endpoint and token fields in settings
- implement helper utilities to find settings by API
- test helper functions

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be59911ac8324a00a4a261869cf2c