### PR TITLE
Add endpoint and token inputs

### DIFF
--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -80,6 +80,32 @@
                 </el-select>
               </div>
             </div>
+            <div v-if="settingForm.api === 'open-webui'" class="setting-row">
+              <div class="setting-group">
+                <label class="compact-label">{{
+                  $t('openwebEndpointLabel')
+                }}</label>
+                <el-input
+                  v-model="settingForm.openwebEndpoint"
+                  class="compact-select"
+                  size="small"
+                  :placeholder="$t('openwebEndpointPlaceholder')"
+                />
+              </div>
+              <div class="setting-group">
+                <label class="compact-label">{{
+                  $t('openwebTokenLabel')
+                }}</label>
+                <el-input
+                  v-model="settingForm.openwebToken"
+                  class="compact-select"
+                  size="small"
+                  type="password"
+                  show-password
+                  :placeholder="$t('openwebTokenPlaceholder')"
+                />
+              </div>
+            </div>
           </div>
         </el-card>
       </div>

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,12 @@
+export function setCookie(name: string, value: string) {
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(
+    value
+  )}; path=/; max-age=315360000`
+}
+
+export function getCookie(name: string): string {
+  const match = document.cookie.match(
+    new RegExp('(?:^|; )' + encodeURIComponent(name) + '=([^;]*)')
+  )
+  return match ? decodeURIComponent(match[1]) : ''
+}

--- a/src/utils/settingPreset.ts
+++ b/src/utils/settingPreset.ts
@@ -2,6 +2,7 @@ import { i18n } from '@/i18n'
 import { forceNumber, optionLists } from './common'
 import { availableModelsForOpenweb } from './constant'
 import { localStorageKey } from './enum'
+import { setCookie, getCookie } from './cookie'
 
 type componentType = 'input' | 'select' | 'inputNum'
 
@@ -94,7 +95,17 @@ export const settingPreset: Record<SettingNames, ISettingOption> = {
     type: 'select',
     optionList: optionLists.replyLanguageList
   },
-  openwebEndpoint: defaultInputSetting,
+  openwebEndpoint: {
+    ...defaultInputSetting,
+    getFunc: () =>
+      getCookie(localStorageKey.openwebEndpoint) ||
+      localStorage.getItem(localStorageKey.openwebEndpoint) ||
+      '',
+    saveFunc: (value: string) => {
+      localStorage.setItem(localStorageKey.openwebEndpoint, value)
+      setCookie(localStorageKey.openwebEndpoint, value)
+    }
+  },
   openwebModelSelect: selectSetting(
     '',
     'openwebModel',
@@ -103,5 +114,15 @@ export const settingPreset: Record<SettingNames, ISettingOption> = {
   ),
   openwebTemperature: inputNumSetting(0.7, 'openwebTemperature', 'temperature'),
   openwebCollections: defaultInputSetting,
-  openwebToken: defaultInputSetting
+  openwebToken: {
+    ...defaultInputSetting,
+    getFunc: () =>
+      getCookie(localStorageKey.openwebToken) ||
+      localStorage.getItem(localStorageKey.openwebToken) ||
+      '',
+    saveFunc: (value: string) => {
+      localStorage.setItem(localStorageKey.openwebToken, value)
+      setCookie(localStorageKey.openwebToken, value)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- allow customizing open-webui endpoint and token in the quick settings section
- save and load these values using persistent cookies

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684beb1a3a548324836a27966625626d